### PR TITLE
Fix for hasChanged() after calling set() without changing the value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,13 @@ function setNested(obj, path, val, options) {
 		} else {
 			//Create the child object if it doesn't exist, or isn't an object
 			if (typeof result[field] === 'undefined' || !_.isObject(result[field])) {
+				// If trying to remove a field that doesn't exist, then there's no need
+				// to create its missing parent (doing so causes a problem with
+				// hasChanged()).
+				if (options.unset) {
+					delete result[field]; // in case parent exists but is not an object
+					return;
+				}
 				var nextField = fields[i + 1];
 
 				// create array if next field is integer, else create object

--- a/test/hasChanged.js
+++ b/test/hasChanged.js
@@ -81,6 +81,24 @@ describe('DeepModel', function() {
 			});
 			expect(deepModel.hasChanged('foo.bar')).to.be.true;
 		});
+
+
+		it('hasChanged(attr): with unchanged deep attributes', function() {
+			var deepModel = new DeepModel({
+				foo: {
+					bar: 1
+				}
+			});
+
+			expect(deepModel.hasChanged('foo.bar')).to.be.false
+			expect(deepModel.hasChanged('foo')).to.be.false
+
+			deepModel.set({
+				'foo.bar': 1
+			});
+			expect(deepModel.hasChanged('foo.bar')).to.be.false;
+			expect(deepModel.hasChanged('foo')).to.be.false;
+		});
 	});
 
 

--- a/test/unset.js
+++ b/test/unset.js
@@ -65,6 +65,54 @@ describe('DeepModel', function() {
 			});
 		});
 
+		it('unset: Unset a non-existent key', function() {
+			var model = new DeepModel(bioData);
+			model.unset('foo.bar');
+
+			expect(model.get('user')).to.deep.equal({
+				type: 'Spy',
+				name: {
+					first: 'Sterling',
+					last: 'Archer'
+				}
+			});
+
+			expect(model.toJSON()).to.deep.equal({
+				id: 123,
+				user: {
+					type: 'Spy',
+					name: {
+						first: 'Sterling',
+						last: 'Archer'
+					}
+				}
+			});
+		});
+
+		it('unset: Unset a non-existent deep key', function() {
+			var model = new DeepModel(bioData);
+			model.unset('user.name.middle');
+
+			expect(model.get('user')).to.deep.equal({
+				type: 'Spy',
+				name: {
+					first: 'Sterling',
+					last: 'Archer'
+				}
+			});
+
+			expect(model.toJSON()).to.deep.equal({
+				id: 123,
+				user: {
+					type: 'Spy',
+					name: {
+						first: 'Sterling',
+						last: 'Archer'
+					}
+				}
+			});
+		});
+
 		it('unset: Unset a deeper key', function() {
 			var model = new DeepModel(bioData);
 			model.unset('user.name.last');


### PR DESCRIPTION
I just encountered some problems caused by https://github.com/powmedia/backbone-deep-model/issues/67. It seems like an easy fix that's working for me.