### PR TITLE
added keyPathUseArrayIndex configuration option

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -179,5 +179,13 @@ describe('DeepModel', function() {
 			expect(model.attributes.date).to.be.instanceof(Date);
 		});
 
+		it("set: Objects with decimal-like keys ", function() {
+			var model = new DeepModel();
+			model.set({
+				'4.5': 4.5
+			});
+			expect(model.attributes['4.5']).to.equal(4.5);
+		});
+
 	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -180,11 +180,17 @@ describe('DeepModel', function() {
 		});
 
 		it("set: Objects with decimal-like keys ", function() {
-			var model = new DeepModel();
+			var model = new DeepModel(),
+				origOpt = DeepModel.keyPathUseArrayIndex; // save option value
+			
+			DeepModel.keyPathUseArrayIndex = true;
+			
 			model.set({
 				'4.5': 4.5
 			});
 			expect(model.attributes['4.5']).to.equal(4.5);
+
+			DeepModel.keyPathUseArrayIndex = true; // restore
 		});
 
 	});


### PR DESCRIPTION
This is to allow array indexes to be used together with the selected keyPathSeparator. The option is disabled by default but when enabled will allow to access deep fields like `some.deep.arrayField[0].prop`

It also takes care of the issue described in #35

Cheers
